### PR TITLE
Tweak Redis health command

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
     networks:
       - app-network
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      test: ["CMD-SHELL", "redis-cli -a null ping | grep PONG"] 
       interval: 10s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
Added the default password set in the command parameter to the healthcheck parameter, allowing health checking to work properly again. I'm not sure if this was unintended behavior, given it's setting the password as 'null', but health checking refuses to work otherwise.