### PR TITLE
Fix: Dashboard Login Loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,7 +86,7 @@ HTTP_GATEWAY_IMAGE=
 SHADER_IMAGE=
 ## Default: ghcr.io/ticketsbot/cache-sync-service:a4bf4a98848094435d017d90c2cfc09a04146ef3
 CACHESYNC_IMAGE=
-## Default: ghcr.io/ticketsbot/api:8f5d68ab0de450a60202788c4c660f2ebdb8c47c
+## Default: ghcr.io/ticketsbot/api:07943c2e1a9b8788d030b4b19db3e656513b6481
 API_IMAGE=
 ## Default: ghcr.io/ticketsbot/logarchiver:0cfab8ec82cfaa88af9e6fabe4dd9a407f7537dd
 LOGARCHIVER_IMAGE=

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -302,7 +302,7 @@ services:
       - app-network
   
   api:
-    image: ${API_IMAGE:-ghcr.io/ticketsbot/api:8f5d68ab0de450a60202788c4c660f2ebdb8c47c}
+    image: ${API_IMAGE:-ghcr.io/ticketsbot/api:07943c2e1a9b8788d030b4b19db3e656513b6481}
     restart: on-failure:10
     ports:
       - '8082:8081'


### PR DESCRIPTION
This PR is made to update the image hashes in correlation with the recently merged TicketsBot/dashboard#37 PR.

The merged PR fixes a bug with the api's callback route which now always returns the `guilds` property.

Previous behavior would only return `guilds`, if there was a guild that was setup. Causing the frontend (aka dashboard) thinking it failed to authenticate, redirecting to the login page again. Thus causing the dashboard login loop...