### PR TITLE
feat: add configurable dashboard Git URL and branch to environment an…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,5 +107,9 @@ AUTOCLOSEDAEMOON_IMAGE=
 DISCORD_CHAT_REPLICA_IMAGE=
 ## Default: ghcr.io/ticketsbot-cloud/import-sync:e5557bccf8771fc9bbe349e62487c28253027461
 IMPORT_SYNC_IMAGE=
+## Default: https://github.com/TicketsBot-cloud/dashboard
+DASHBOARD_GIT_URL=
+## Default: master
+DASHBOARD_GIT_BRANCH=
 ## Default: 27b2c0e8c63dc66ed9c715823dcfd2b57c1a4beb
 DASHBOARD_COMMIT_HASH=

--- a/dashboard.Dockerfile
+++ b/dashboard.Dockerfile
@@ -11,10 +11,12 @@ USER node
 
 # Bust cache (this will allow it to pull the latest version of the dashboard from the repo)
 ARG CACHEBUST=1
+ARG GIT_URL=https://github.com/TicketsBot-cloud/dashboard
+ARG GIT_BRANCH=master
 ARG COMMIT_HASH=27b2c0e8c63dc66ed9c715823dcfd2b57c1a4beb
 
 # Clone the repository to /tmp
-RUN git clone https://github.com/TicketsBot-cloud/dashboard.git /tmp
+RUN git clone -b $GIT_BRANCH $GIT_URL.git /tmp
 
 # Switch to "known-working" commit.
 RUN git reset --hard $COMMIT_HASH

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -368,6 +368,8 @@ services:
         REDIRECT_URI: ${DASHBOARD_URL:-http://localhost:5000}/callback 
         API_URL: ${API_URL:-http://localhost:8082}
         WS_URL: ${API_URL:-http://localhost:8082}
+        GIT_URL: ${DASHBOARD_GIT_URL:-https://github.com/TicketsBot-cloud/dashboard}
+        GIT_BRANCH: ${DASHBOARD_GIT_BRANCH:-master}
         COMMIT_HASH: ${DASHBOARD_COMMIT_HASH:-27b2c0e8c63dc66ed9c715823dcfd2b57c1a4beb}
         CACHEBUST: "this is randeom" # (OPTIONAL) Change this whenever you update the dashboard repository
     ports:


### PR DESCRIPTION
This pull request includes changes to the configuration files and Docker setup to make the repository URLs and branches configurable. The most important changes include adding new environment variables for the dashboard repository URL and branch, updating the Dockerfile to use these variables, and modifying the `docker-compose.yaml` file to pass these variables to the services.

Configuration updates:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR110-R113): Added `DASHBOARD_GIT_URL` and `DASHBOARD_GIT_BRANCH` environment variables with default values.

Docker setup improvements:

* [`dashboard.Dockerfile`](diffhunk://#diff-39d6a74751bb327b2524e45991fab5510a58adb648e8ad6b7ac325e52aeaac15R14-R19): Introduced `GIT_URL` and `GIT_BRANCH` arguments to allow specifying the repository URL and branch for the dashboard. Updated the `git clone` command to use these arguments.
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R371-R372): Added `GIT_URL` and `GIT_BRANCH` environment variables to the `services` section, with default values set to the new environment variables.