### PR TITLE
Fix bot config urls (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ As this bot is self-hosted, you will need to configure the bot yourself. Here ar
    - Replace `${DISCORD_BOT_CLIENT_ID}` with your bot's application/client ID (e.g. `508391840525975553`)
 4. Go to the OAuth2 tab
 5. Add the redirect URL `${DASHBOARD_URL}/callback` to the OAuth2 redirect URIs
-   - Replace `${DASHBOARD_URL}` with the URL of your dashboard (e. g. `http://localhost:5000` make sure this matches what you set in the [Setup](#setup) section)
+   - Replace `${DASHBOARD_URL}` with the URL of your dashboard (e. g. `http://localhost:5000`, make sure this matches what you set in the [Setup](#setup) section)
 6. Go to the Bot tab
 7. Enable the `Server Members Intent` and `Message Content Intent` toggles
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ As this bot is self-hosted, you will need to configure the bot yourself. Here ar
    - Replace `${HTTP_GATEWAY}` with the URL of your HTTP Gateway (e.g. `https://gateway.example.com`, you must have a [publicly accessible URL](./wiki/faq.md#6-i-want-anyone-to-be-able-to-use-the-dashboard-how-do-i-do-that) not localhost)
    - Replace `${DISCORD_BOT_CLIENT_ID}` with your bot's application/client ID (e.g. `508391840525975553`)
 4. Go to the OAuth2 tab
-5. Add the redirect URL `${DASHBOARD_URL}/callback` to the OAuth2 redirect URIs
-   - Replace `${DASHBOARD_URL}` with the URL of your API (e.g. `http://localhost:8080`, make sure this matches what you set in the [Setup](#setup) section)
+5. Add the redirect URLs `${DASHBOARD_URL}/callback` and `${API_URL}/callback` to the OAuth2 redirect URIs
+   - Replace `${DASHBOARD_URL}` with the URL of your dashboard (e. g. `http://localhost:5000`) and `${API_URL}` with the URL of you API (e.g. `http://localhost:8082`) (make sure this matches what you set in the [Setup](#setup) section)
 6. Go to the Bot tab
 7. Enable the `Server Members Intent` and `Message Content Intent` toggles
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ As this bot is self-hosted, you will need to configure the bot yourself. Here ar
    - Replace `${HTTP_GATEWAY}` with the URL of your HTTP Gateway (e.g. `https://gateway.example.com`, you must have a [publicly accessible URL](./wiki/faq.md#6-i-want-anyone-to-be-able-to-use-the-dashboard-how-do-i-do-that) not localhost)
    - Replace `${DISCORD_BOT_CLIENT_ID}` with your bot's application/client ID (e.g. `508391840525975553`)
 4. Go to the OAuth2 tab
-5. Add the redirect URLs `${DASHBOARD_URL}/callback` and `${API_URL}/callback` to the OAuth2 redirect URIs
-   - Replace `${DASHBOARD_URL}` with the URL of your dashboard (e. g. `http://localhost:5000`) and `${API_URL}` with the URL of you API (e.g. `http://localhost:8082`) (make sure this matches what you set in the [Setup](#setup) section)
+5. Add the redirect URL `${DASHBOARD_URL}/callback` to the OAuth2 redirect URIs
+   - Replace `${DASHBOARD_URL}` with the URL of your dashboard (e. g. `http://localhost:5000` make sure this matches what you set in the [Setup](#setup) section)
 6. Go to the Bot tab
 7. Enable the `Server Members Intent` and `Message Content Intent` toggles
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -65,8 +65,8 @@ Da dieser bot selbst-gehosted ist, musst du, denn bot selbst konfigurieren. Hier
    - Ersetzte `${HTTP_GATEWAY}` mit der URL deines HTTP Gateway (z.B. `https://gateway.example.com`, Du must eine [öffentlich erreichbare URL](./wiki/faq.md#6-i-want-anyone-to-be-able-to-use-the-dashboard-how-do-i-do-that) haben nicht localhost)
    - Ersetze `${DISCORD_BOT_CLIENT_ID}` mit deiner bot application/client ID (z.B. `508391840525975553`)
 4. Gehe in das OAuth2 tab
-5. Füge die redirect URL `${DASHBOARD_URL}/callback` zu den OAuth2 redirect URIs hinzu
-   - Ersetze `${DASHBOARD_URL}` mit der URL deiner API (z.B. `http://localhost:8080`, Stelle sicher das diese, mit der URL, die du, in dem [Setup](#setup) abschnitt gesetzt hast, überein stimmt)
+5. Füge die redirect URLs `${DASHBOARD_URL}/callback` und `${API_URL}/callback`zu den OAuth2 redirect URIs hinzu
+   - Ersetze `${DASHBOARD_URL}` mit der URL deines Dashboards (z. B. `http://localhost:5000`) und `${API_URL}` mit der URL deiner API (z.B. `http://localhost:8082`) (Stelle sicher das diese, mit der URL, die du, in dem [Setup](#setup) abschnitt gesetzt hast, überein stimmt)
 6. Gehe in das Bot tab
 7. Schalte die `Server Members Intent` und `Message Content Intent` schalter an
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -65,8 +65,8 @@ Da dieser bot selbst-gehosted ist, musst du, denn bot selbst konfigurieren. Hier
    - Ersetzte `${HTTP_GATEWAY}` mit der URL deines HTTP Gateway (z.B. `https://gateway.example.com`, Du must eine [öffentlich erreichbare URL](./wiki/faq.md#6-i-want-anyone-to-be-able-to-use-the-dashboard-how-do-i-do-that) haben nicht localhost)
    - Ersetze `${DISCORD_BOT_CLIENT_ID}` mit deiner bot application/client ID (z.B. `508391840525975553`)
 4. Gehe in das OAuth2 tab
-5. Füge die redirect URLs `${DASHBOARD_URL}/callback` und `${API_URL}/callback`zu den OAuth2 redirect URIs hinzu
-   - Ersetze `${DASHBOARD_URL}` mit der URL deines Dashboards (z. B. `http://localhost:5000`) und `${API_URL}` mit der URL deiner API (z.B. `http://localhost:8082`) (Stelle sicher das diese, mit der URL, die du, in dem [Setup](#setup) abschnitt gesetzt hast, überein stimmt)
+5. Füge die redirect URL `${DASHBOARD_URL}/callback` zu den OAuth2 redirect URIs hinzu
+   - Ersetze `${DASHBOARD_URL}` mit der URL deines Dashboards (z. B. `http://localhost:5000`, Stelle sicher das diese, mit der URL, die du, in dem [Setup](#setup) abschnitt gesetzt hast, überein stimmt)
 6. Gehe in das Bot tab
 7. Schalte die `Server Members Intent` und `Message Content Intent` schalter an
 

--- a/README_NL.md
+++ b/README_NL.md
@@ -66,8 +66,8 @@ Aangezien deze bot zelf gehost wordt, zul je de bot zelf moeten configureren. Hi
    - vervang `${HTTP_GATEWAY}` met de URL van je HTTP-gateway (e.g. `https://gateway.example.com`, Je moet wel een [openbaar URL](./wiki/faq.md#6-i-want-anyone-to-be-able-to-use-the-dashboard-how-do-i-do-that) Geen localhost)
    - vervangen `${DISCORD_BOT_CLIENT_ID}` met de applicatie-/client-ID van je bot (e.g. `508391840525975553`)
 4. ga naar te OAuth2 tab
-5. Voeg de redirect-URL toe `${DASHBOARD_URL}/callback` aan de OAuth2-redirect-URI's
-   - vervang `${DASHBOARD_URL}` met de URL van je API (e.g. `http://localhost:8080`,  zorg ervoor dat dit overeenkomt met wat je hebt ingesteld in de [opstelling](#opstelling) section)
+5. Voeg de redirect-URL's `${DASHBOARD_URL}/callback` en `${API_URL}/callback` toe aan de OAuth2-redirect-URI's
+   - Vervang `${DASHBOARD_URL}` door de URL van uw dashboard (e. g. `http://localhost:5000`) en `${API_URL}` door de URL van uw API (e. g. `http://localhost:8082`) ( zorg ervoor dat dit overeenkomt met wat je hebt ingesteld in de [opstelling](#opstelling) section)
 6. Ga naar het tabblad 'Bot
 7. Schakel de wisselknoppen `Server Members Intent` en `Message Content Intent` in
 

--- a/README_NL.md
+++ b/README_NL.md
@@ -66,8 +66,8 @@ Aangezien deze bot zelf gehost wordt, zul je de bot zelf moeten configureren. Hi
    - vervang `${HTTP_GATEWAY}` met de URL van je HTTP-gateway (e.g. `https://gateway.example.com`, Je moet wel een [openbaar URL](./wiki/faq.md#6-i-want-anyone-to-be-able-to-use-the-dashboard-how-do-i-do-that) Geen localhost)
    - vervangen `${DISCORD_BOT_CLIENT_ID}` met de applicatie-/client-ID van je bot (e.g. `508391840525975553`)
 4. ga naar te OAuth2 tab
-5. Voeg de redirect-URL's `${DASHBOARD_URL}/callback` en `${API_URL}/callback` toe aan de OAuth2-redirect-URI's
-   - Vervang `${DASHBOARD_URL}` door de URL van uw dashboard (e. g. `http://localhost:5000`) en `${API_URL}` door de URL van uw API (e. g. `http://localhost:8082`) ( zorg ervoor dat dit overeenkomt met wat je hebt ingesteld in de [opstelling](#opstelling) section)
+5. Voeg de redirect-URL toe `${DASHBOARD_URL}/callback` aan de OAuth2-redirect-URI's
+   - vervang `${DASHBOARD_URL}` met de URL van je Dashboard (e.g. `http://localhost:5000`, zorg ervoor dat dit overeenkomt met wat je hebt ingesteld in de [opstelling](#opstelling) section)
 6. Ga naar het tabblad 'Bot
 7. Schakel de wisselknoppen `Server Members Intent` en `Message Content Intent` in
 


### PR DESCRIPTION
## This PR fixes an issue in the readme files, located in the Bot configuration section in step 5.

The error was that the example URL for API_URL was `http://localhost:8080` instead of `http://localhost:8082`

Now it will ask you to add `${DASHBOARD_URL}/callback` and `${API_URL}/callback` which from my testing are both required. Their description also got updated to include both of these URL's correctly and with the correct examples.

This change has been done in all Translations currently available.