### PR TITLE
FIX: readme's, wiki, .env and compose file to use new port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ ADMIN_USER_IDS=
 DISCORD_SUPPORT_SERVER_INVITE=
 
 # URLs - Required
-## Default: http://localhost:5000
+## Default: http://localhost:8000
 DASHBOARD_URL=
 ## Default: http://localhost:8082
 API_URL=

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The image above was made using [Excalidraw](https://excalidraw.com/).
    - `DISCORD_BOT_PUBLIC_KEY`: your bot's public key (e.g. `fcd10216ebbc818d7ef1408a5c3c5702225b929b53b0a265b82e82b96a9a8358`)
    - `ADMIN_USER_IDS`: a comma-separated list of user IDs (e.g. `209796601357533184,585576154958921739,user_id,user_id`, a single id would be `209796601357533184`)
    - `DISCORD_SUPPORT_SERVER_INVITE`: the invite link to your support server (e.g. `https://discord.gg/ticketsbot`)
-   - `DASHBOARD_URL`: the URL of your dashboard (e.g. `http://localhost:5000`)
+   - `DASHBOARD_URL`: the URL of your dashboard (e.g. `http://localhost:8000`)
    - `LANDING_PAGE_URL`: the URL of your landing page (e.g. `https://ticketsbot.cloud`)
    - `API_URL`: the URL of your API (e.g. `http://localhost:8082`)
    - `DATABASE_HOST`: your PostgreSQL host (e.g. `postgres:5432`)
@@ -67,7 +67,7 @@ As this bot is self-hosted, you will need to configure the bot yourself. Here ar
    - Replace `${DISCORD_BOT_CLIENT_ID}` with your bot's application/client ID (e.g. `508391840525975553`)
 4. Go to the OAuth2 tab
 5. Add the redirect URL `${DASHBOARD_URL}/callback` to the OAuth2 redirect URIs
-   - Replace `${DASHBOARD_URL}` with the URL of your dashboard (e. g. `http://localhost:5000`, make sure this matches what you set in the [Setup](#setup) section)
+   - Replace `${DASHBOARD_URL}` with the URL of your dashboard (e. g. `http://localhost:8000`, make sure this matches what you set in the [Setup](#setup) section)
 6. Go to the Bot tab
 7. Enable the `Server Members Intent` and `Message Content Intent` toggles
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -29,7 +29,7 @@ Das obrige Bild, wurde mit [Excalidraw](https://excalidraw.com/) erstellt.
    - `DISCORD_BOT_PUBLIC_KEY`: dein bot public key (z.B. `fcd10216ebbc818d7ef1408a5c3c5702225b929b53b0a265b82e82b96a9a8358`)
    - `ADMIN_USER_IDS`: ein komma separiert die liste mit benutzer IDs (z.B. `209796601357533184,585576154958921739,user_id,user_id`, eine einzelne ID wäre `209796601357533184`)
    - `DISCORD_SUPPORT_SERVER_INVITE`: der invite link zu deinem support server (z.B. `https://discord.gg/ticketsbot`)
-   - `DASHBOARD_URL`: die URL deines dashboards (z.B. `http://localhost:5000`)
+   - `DASHBOARD_URL`: die URL deines dashboards (z.B. `http://localhost:8000`)
    - `LANDING_PAGE_URL`: die URL deiner home page (z.B. `https://ticketsbot.cloud`)
    - `API_URL`: die URL deiner API (z.B. `http://localhost:8082`)
    - `DATABASE_HOST`: dein PostgreSQL host (z.B. `postgres:5432`)
@@ -66,7 +66,7 @@ Da dieser bot selbst-gehosted ist, musst du, denn bot selbst konfigurieren. Hier
    - Ersetze `${DISCORD_BOT_CLIENT_ID}` mit deiner bot application/client ID (z.B. `508391840525975553`)
 4. Gehe in das OAuth2 tab
 5. Füge die redirect URL `${DASHBOARD_URL}/callback` zu den OAuth2 redirect URIs hinzu
-   - Ersetze `${DASHBOARD_URL}` mit der URL deines Dashboards (z. B. `http://localhost:5000`, Stelle sicher das diese, mit der URL, die du, in dem [Setup](#setup) abschnitt gesetzt hast, überein stimmt)
+   - Ersetze `${DASHBOARD_URL}` mit der URL deines Dashboards (z. B. `http://localhost:8000`, Stelle sicher das diese, mit der URL, die du, in dem [Setup](#setup) abschnitt gesetzt hast, überein stimmt)
 6. Gehe in das Bot tab
 7. Schalte die `Server Members Intent` und `Message Content Intent` schalter an
 

--- a/README_NL.md
+++ b/README_NL.md
@@ -29,7 +29,7 @@ De bovenstaande afbeelding is gemaakt met [Excalidraw](https://excalidraw.com/).
    - `DISCORD_BOT_PUBLIC_KEY`: de openbare sleutel van je bot (e.g. `fcd10216ebbc818d7ef1408a5c3c5702225b929b53b0a265b82e82b96a9a8358`)
    - `ADMIN_USER_IDS`: een komma-gescheiden lijst van gebruikers IDs (e.g. `209796601357533184,585576154958921739,user_id,user_id`, een enkele id zou zijn `209796601357533184`)
    - `DISCORD_SUPPORT_SERVER_INVITE`: de uitnodigingslink naar je ondersteuningsserver (e.g. `https://discord.gg/ticketsbot`)
-   - `DASHBOARD_URL`: de URL van je dashboard (e.g. `http://localhost:5000`)
+   - `DASHBOARD_URL`: de URL van je dashboard (e.g. `http://localhost:8000`)
    - `LANDING_PAGE_URL`: de URL van je landingspagina (e.g. `https://ticketsbot.cloud`)
    - `API_URL`: de URL van je API (e.g. `http://localhost:8082`)
    - `DATABASE_HOST`: je PostgreSQL-host (e.g. `postgres:5432`)
@@ -67,7 +67,7 @@ Aangezien deze bot zelf gehost wordt, zul je de bot zelf moeten configureren. Hi
    - vervangen `${DISCORD_BOT_CLIENT_ID}` met de applicatie-/client-ID van je bot (e.g. `508391840525975553`)
 4. ga naar te OAuth2 tab
 5. Voeg de redirect-URL toe `${DASHBOARD_URL}/callback` aan de OAuth2-redirect-URI's
-   - vervang `${DASHBOARD_URL}` met de URL van je Dashboard (e.g. `http://localhost:5000`, zorg ervoor dat dit overeenkomt met wat je hebt ingesteld in de [opstelling](#opstelling) section)
+   - vervang `${DASHBOARD_URL}` met de URL van je Dashboard (e.g. `http://localhost:8000`, zorg ervoor dat dit overeenkomt met wat je hebt ingesteld in de [opstelling](#opstelling) section)
 6. Ga naar het tabblad 'Bot
 7. Schakel de wisselknoppen `Server Members Intent` en `Message Content Intent` in
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -112,7 +112,7 @@ services:
     environment:
       WORKER_MODE: INTERACTIONS
 
-      DASHBOARD_URL: ${DASHBOARD_URL:-http://localhost:5000}
+      DASHBOARD_URL: ${DASHBOARD_URL:-http://localhost:8000}
       FRONTPAGE_URL: ${LANDING_PAGE_URL:-https://ticketsbot.cloud}
       VOTE_URL: ${VOTE_URL:-https://vote.ticketsbot.cloud}
       POWEREDBY: ${POWERED_BY:-github.com/ticketsbot-cloud}
@@ -176,7 +176,7 @@ services:
       # WORKER_DEBUG: 
       WORKER_MODE: GATEWAY
 
-      DASHBOARD_URL: ${DASHBOARD_URL:-http://localhost:5000}
+      DASHBOARD_URL: ${DASHBOARD_URL:-http://localhost:8000}
       FRONTPAGE_URL: ${LANDING_PAGE_URL:-https://ticketsbot.cloud}
       VOTE_URL: ${VOTE_URL:-https://vote.ticketsbot.cloud}
       POWEREDBY: ${POWERED_BY:-github.com/ticketsbot-cloud}
@@ -320,7 +320,7 @@ services:
       - '8082:8081'
     environment:
       SERVER_ADDR: 0.0.0.0:8081
-      BASE_URL: ${DASHBOARD_URL:-http://localhost:5000}
+      BASE_URL: ${DASHBOARD_URL:-http://localhost:8000}
       MAIN_SITE: ${LANDING_PAGE_URL:-https://ticketsbot.cloud} # Home/Landing (used for /premium)
       DATABASE_URI: 'postgres://postgres:${DATABASE_PASSWORD:-null}@postgres/ticketsbot'
       REDIS_HOST: ${REDIS_HOST:-redis}
@@ -334,7 +334,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       OAUTH_ID: ${DISCORD_BOT_CLIENT_ID}
       OAUTH_SECRET: '${DISCORD_BOT_OAUTH_SECRET}'
-      OAUTH_REDIRECT_URI: '${DASHBOARD_URL:-http://localhost:5000}/callback'
+      OAUTH_REDIRECT_URI: '${DASHBOARD_URL:-http://localhost:8000}/callback'
       BOT_ID: ${DISCORD_BOT_CLIENT_ID}
       BOT_TOKEN: '${DISCORD_BOT_TOKEN}'
       CACHE_URI: postgres://postgres:${CACHE_DATABASE_PASSWORD:-null}@postgres-cache/botcache
@@ -370,7 +370,7 @@ services:
       dockerfile: './dashboard.Dockerfile'
       args:
         CLIENT_ID: ${DISCORD_BOT_CLIENT_ID}
-        REDIRECT_URI: ${DASHBOARD_URL:-http://localhost:5000}/callback 
+        REDIRECT_URI: ${DASHBOARD_URL:-http://localhost:8000}/callback 
         API_URL: ${API_URL:-http://localhost:8082}
         WS_URL: ${API_URL:-http://localhost:8082}
         GIT_URL: ${DASHBOARD_GIT_URL:-https://github.com/TicketsBot-cloud/dashboard}

--- a/wiki/common-issues.md
+++ b/wiki/common-issues.md
@@ -20,9 +20,9 @@ The most common error is that the URL you inputted is not publicly accessible (a
 
 ## 3. Invalid OAuth2 redirect_uri
 
-> :warning: If you set up a [reverse proxy](#6-i-want-anyone-to-be-able-to-use-the-dashboard-how-do-i-do-that), you should use the dashboard domain (e.g. `https://dashboard.example.com`) you set instead of `http://localhost:5000`.
+> :warning: If you set up a [reverse proxy](#6-i-want-anyone-to-be-able-to-use-the-dashboard-how-do-i-do-that), you should use the dashboard domain (e.g. `https://dashboard.example.com`) you set instead of `http://localhost:8000`.
 
-This error is caused by you not setting the OAuth2 redirect URI in the [Discord Bot Configuration](#discord-bot-configuration) section. You need to set the redirect URI to `${DASHBOARD_URL}/callback`. Replace `${DASHBOARD_URL}` with the URL of your dashboard (e.g. `http://localhost:5000`).
+This error is caused by you not setting the OAuth2 redirect URI in the [Discord Bot Configuration](#discord-bot-configuration) section. You need to set the redirect URI to `${DASHBOARD_URL}/callback`. Replace `${DASHBOARD_URL}` with the URL of your dashboard (e.g. `http://localhost:8000`).
 
 If have already started the bot once and you've changed the `DASHBOARD_URL` in the `.env` file, you will need to delete the `dashboard` image. The "easy way" is to run `docker compose up dashboard -d --force-recreate --build` to force the dashboard to rebuild. This will not delete the images, but it will recreate the container with the new environment variables.
 

--- a/wiki/faq.md
+++ b/wiki/faq.md
@@ -45,7 +45,7 @@ You have to setup a reverse proxy (examples being; [NginX](https://nginx.org/), 
 > :warning: I assume you are using the default ports from the compose file, if you are not, you will have to change the ports in the examples below.
 
 - `api.example.com` -> `http://localhost:8082` (api container)
-- `dashboard.example.com` -> `http://localhost:5000` (dashboard container)
+- `dashboard.example.com` -> `http://localhost:8000` (dashboard container)
 - `gateway.example.com` -> `http://localhost:8080` (http-gateway container)
 
 ## 7. This requires S3, can I host this without S3? (NOT recommended)


### PR DESCRIPTION
This PR changes the Wiki's, readme's, .env and the compose file to use the new localhost Dashboard URL (localhost:8000) as the placeholders/example's/defaults. 
This should fix any confusions with the Localhost URL for the Dashboard not working.