### PR TITLE
Bump import-sync-transcripts and change dashboard port back to 5000

### DIFF
--- a/dashboard.Dockerfile
+++ b/dashboard.Dockerfile
@@ -51,4 +51,4 @@ COPY --from=build --chown=node:node /tmp/frontend/node_modules /app/node_modules
 COPY --from=build --chown=node:node /tmp/frontend/public /app/public
 
 ENV NODE_ENV=production
-CMD ["npm", "run", "start"]
+CMD ["npx", "sirv", "public", "-s", "--no-clear", "--host", "0.0.0.0", "--port", "5000"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -331,7 +331,7 @@ services:
       RATELIMIT_MAX: 10
       RealIpHeaders: ${REAL_IP_HEADERS:-X-Forwarded-For}
       TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.1,172.21.0.1}
-      JWT_SECRET: ${JWT_SECRET}
+      JWT_SECRET: ${JWT_SECRET:-}
       OAUTH_ID: ${DISCORD_BOT_CLIENT_ID}
       OAUTH_SECRET: '${DISCORD_BOT_OAUTH_SECRET}'
       OAUTH_REDIRECT_URI: '${DASHBOARD_URL:-http://localhost:5000}/callback'
@@ -378,7 +378,7 @@ services:
         COMMIT_HASH: ${DASHBOARD_COMMIT_HASH:-2441d52b1df85168d57e398fe2c90eec1a5c642b}
         INVITE_URL: https://discord.com/oauth2/authorize?client_id=${DISCORD_BOT_CLIENT_ID}&scope=bot+applications.commands&permissions=395942816984
     ports:
-      - '5000:8000'
+      - '5000:5000'
     networks:
       - app-network
 
@@ -481,7 +481,7 @@ services:
       - app-network
 
   import-sync-transcripts:
-    image: ${IMPORT_SYNC_IMAGE:-ghcr.io/ticketsbot-cloud/import-sync:e5557bccf8771fc9bbe349e62487c28253027461}
+    image: ${IMPORT_SYNC_IMAGE:-ghcr.io/ticketsbot-cloud/import-sync:dc709612edbd83a5e3704eb609db0cd6a82c3402}
     environment:
       DAEMON_ENABLED: true
       DAEMON_FREQUENCY: 2m


### PR DESCRIPTION
Changes:

- Bump import-sync-transcripts (to the same version as import-sync-data)
- Change dashboard port back to 5000 (from the new 8000)
- Added default for JWT_SECRET for api container