### PR TITLE
FIX: add Redis Static Volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -88,6 +88,8 @@ services:
     command: ["redis-server", "--requirepass", "${REDIS_PASSWORD:-null}"]
     # ports: # Uncomment this line and the following line to access redis on port 6479
     #   - "6479:6379"
+    volumes:
+      - redis_data:/data
     networks:
       - app-network
     healthcheck:
@@ -585,6 +587,9 @@ services:
         condition: service_healthy
     networks:
       - app-network
+
+volumes:
+  redis_data:
 
 networks:
   app-network:


### PR DESCRIPTION
This PR adds a Static Volume to Redis to fix a few issues happening with it while composing from a user and not root.
Redis no longer uses a changing volume but a static one. 
This means that you will only have to chown the Redis Volume once instead of each time you compose up.
This new Redis volume is located at: `/var/lib/docker/volumes/ticketsbot_redis_data/_data`

**If you use compose up on user you will need to run `sudo chown -R user:group /var/lib/docker/volumes/ticketsbot_redis_data/_data` for Redis to be healthy while trying to save it's snapshots.**

_This is not mentioned in the README.md file.
Dan you might want to add this info to the README before merging this PR and maybe also that if possible the compose file tries to use your users permissions to create the containers instead of always using root perms?_