### PR TITLE
Add MinIO S3 storage addon with setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /pg*data
 /redisdata
 /kafkadata
+/miniodata
 .env

--- a/addons/README.md
+++ b/addons/README.md
@@ -18,6 +18,12 @@ This package adds both services for the Server Counter. It includes the general 
 
 > **See how to add this package here: [Server Counter: Install](./packages/server-counter/server-counter-package.md)**
 
+### MinIO S3 Storage
+
+This package adds MinIO, a self-hosted S3-compatible object storage service. MinIO is used for storing archived ticket transcripts and import data.
+
+> **See how to add this package here: [MinIO: Install](./packages/minio/README.md)**
+
 ### Clickhouse - Statistics
 
 **Coming Soon™**

--- a/addons/packages/minio/README.md
+++ b/addons/packages/minio/README.md
@@ -1,0 +1,54 @@
+# MinIO S3 Storage
+
+This package adds MinIO, a self-hosted S3-compatible object storage service. MinIO is used for storing archived ticket transcripts and import data.
+
+## What's Included
+
+- **MinIO Server**: S3-compatible object storage service with web console
+- **MinIO Setup**: Automatic bucket creation and configuration
+
+## Installation
+
+1. Navigate to the addons directory:
+   ```bash
+   cd addons/packages/minio
+   ```
+
+2. Make sure your `.env` file contains the required S3 configuration:
+   ```env
+   S3_ACCESS=your_access_key
+   S3_SECRET=your_secret_key
+   S3_ARCHIVE_BUCKET=archive
+   S3_DATA_IMPORT_BUCKET=data-import
+   S3_TRANSCRIPT_IMPORT_BUCKET=transcript-import
+   S3_ENDPOINT=minio:9000
+   S3_SECURE=false
+   ```
+
+3. Start the MinIO services:
+   ```bash
+   docker compose up -d
+   ```
+
+## Access
+
+- **MinIO Console**: http://localhost:9001
+  - Login with the credentials from `S3_ACCESS` and `S3_SECRET`
+
+- **MinIO API**: http://localhost:9000
+  - Used by the bot services for S3 operations
+
+## Configuration
+
+The setup container automatically creates the required buckets:
+- Archive bucket (for ticket transcripts)
+- Data import bucket
+- Transcript import bucket
+
+All buckets are set to public read access by default.
+
+## Notes
+
+- MinIO data is stored in the `miniodata` directory relative to the main docker-compose.yaml location
+- The MinIO setup container runs once to create buckets and then exits
+- If you need to recreate buckets, you can run `docker compose up minio-setup` again

--- a/addons/packages/minio/docker-compose.yaml
+++ b/addons/packages/minio/docker-compose.yaml
@@ -1,0 +1,51 @@
+services:
+  minio:
+    image: minio/minio:latest
+    container_name: minio
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET}
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - ./miniodata:/data
+    networks:
+      - app-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  minio-setup:
+    image: minio/mc:latest
+    container_name: minio-setup
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set myminio http://minio:9000 ${S3_ACCESS} ${S3_SECRET};
+      if mc ls myminio/${S3_ARCHIVE_BUCKET} >/dev/null 2>&1; then
+        echo 'The ${S3_ARCHIVE_BUCKET} bucket already exists';
+      else
+        mc mb myminio/${S3_ARCHIVE_BUCKET};
+        mc anonymous set public myminio/${S3_ARCHIVE_BUCKET};
+      fi;
+      if mc ls myminio/${S3_DATA_IMPORT_BUCKET} >/dev/null 2>&1; then
+        echo 'The ${S3_DATA_IMPORT_BUCKET} bucket already exists';
+      else
+        mc mb myminio/${S3_DATA_IMPORT_BUCKET};
+        mc anonymous set public myminio/${S3_DATA_IMPORT_BUCKET};
+      fi;
+      if mc ls myminio/${S3_TRANSCRIPT_IMPORT_BUCKET} >/dev/null 2>&1; then
+        echo 'The ${S3_TRANSCRIPT_IMPORT_BUCKET} bucket already exists';
+      else
+        mc mb myminio/${S3_TRANSCRIPT_IMPORT_BUCKET};
+        mc anonymous set public myminio/${S3_TRANSCRIPT_IMPORT_BUCKET};
+      fi;
+      "
+    networks:
+      - app-network


### PR DESCRIPTION
Introduces a new MinIO package for self-hosted S3-compatible object storage, including docker-compose configuration and setup instructions. Updates .gitignore to exclude MinIO data and documents the addon in the main README.