### PR TITLE
FEAT: category-update-producer service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,6 +171,8 @@ AUTOCLOSEDAEMON_IMAGE=
 DISCORD_CHAT_REPLICA_IMAGE=
 ## Default: ghcr.io/ticketsbot-cloud/import-sync:d13e9e3aaa58e2e43038f62538cb7ec154d5331e
 IMPORT_SYNC_IMAGE=
+## Default: ghcr.io/ticketsbot-cloud/category-update-producer:1afc139dd8c13394f6cc6a8812187b7832b21c6b
+CATEGORY_UPDATE_PRODUCER_IMAGE=
 ## Default: https://github.com/TicketsBot-cloud/dashboard
 DASHBOARD_GIT_URL=
 ## Default: master

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -611,6 +611,22 @@ services:
         condition: service_healthy
     networks:
       - app-network
+  
+  category-update-producer:
+    image: ${CATEGORY_UPDATE_PRODUCER_IMAGE:-ghcr.io/ticketsbot-cloud/category-update-producer:1afc139dd8c13394f6cc6a8812187b7832b21c6b}
+    user: "${UID:-}:${GID:-}"
+    container_name: category-update-producer
+    environment:
+      SENTRY_DSN: ${SENTRY_DSN} 
+      JSON_LOGS: false
+      DATABASE_URI: postgres://postgres:${DATABASE_PASSWORD:-null}@${DATABASE_HOST:-postgres:5432}/ticketsbot
+      KAFKA_BROKERS: kafka:9092
+      KAFKA_TOPIC: ticketsbot
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - app-network
 
 networks:
   app-network:


### PR DESCRIPTION
This PR adds the category update producer service used to make the awaiting response category work.